### PR TITLE
Android rebase

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2232,13 +2232,10 @@ int API_EXPORTED libusb_set_option(libusb_context *ctx,
 	case LIBUSB_OPTION_WEAK_AUTHORITY:
 	case LIBUSB_OPTION_ANDROID_JNIENV:
 	case LIBUSB_OPTION_ANDROID_JAVAVM:
-		usbi_mutex_static_lock(&default_context_lock);
 		if (usbi_backend.set_option)
 			r = usbi_backend.set_option(ctx, option, ap);
 		else
 			r = LIBUSB_ERROR_NOT_SUPPORTED;
-		usbi_mutex_static_unlock(&default_context_lock);
-
 		return r;
 
 	case LIBUSB_OPTION_MAX:

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -479,8 +479,10 @@ static void op_exit(struct libusb_context *ctx)
 
 static int op_set_option(struct libusb_context *ctx, enum libusb_option option, va_list ap)
 {
-	if (NULL != ctx) {
-		return LIBUSB_ERROR_NOT_SUPPORTED;
+   if ( ctx != NULL ){
+      if (ctx->list.prev != NULL ){
+		   return LIBUSB_ERROR_NOT_SUPPORTED;
+      }
 	}
 
 #ifdef __ANDROID__


### PR DESCRIPTION
@xloem I have committed the changes we talked about.  I also added a check in op_set_option to see if the context was previously initialized (e.g. list.prev != NULL), this will now fail if you call:
libusb_set_option -> libusb_init -> libusb_set_option.  The second call to libusb_set_option will return an error.  
