### PR TITLE
Android JNI - support for device relisting/rescanning

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -430,7 +430,6 @@ static int op_init(struct libusb_context *ctx)
 			&cpriv->android_jni);
 		if (r != LIBUSB_SUCCESS)
 			return r;
-		return android_jni_scan_devices(ctx);
 	}
 #endif
 
@@ -462,7 +461,7 @@ static void op_exit(struct libusb_context *ctx)
 #ifdef __ANDROID__
 	if (cpriv->android_jni != NULL) {
 		android_jni_free(cpriv->android_jni);
-		return;
+		cpriv->android_jni = NULL;
 	}
 #endif
 
@@ -520,7 +519,8 @@ static int op_set_option(struct libusb_context *ctx, enum libusb_option option, 
 
 #ifdef __ANDROID__
 
-static int android_jni_scan_devices(struct libusb_context *ctx)
+#define LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL 32
+int android_jni_scan_devices(struct libusb_context *ctx)
 {
 	/* Access and use the Android API via jni_env */
 
@@ -530,6 +530,10 @@ static int android_jni_scan_devices(struct libusb_context *ctx)
 	struct android_jni_devices *devices;
 	jobject device;
 	uint8_t busnum, devaddr;
+
+	if(cpriv->android_jni == NULL) {
+		return 0;
+	}
 
 	r = android_jni_detect_usbhost(cpriv->android_jni, &has_usbhost);
 
@@ -548,9 +552,22 @@ static int android_jni_scan_devices(struct libusb_context *ctx)
 	if (r != LIBUSB_SUCCESS)
 		return r;
 
+	// for every session id not found, disconnect
+	unsigned long session_id_avail[LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL];
+	size_t session_id_count = 0;
+
 	while (LIBUSB_SUCCESS ==
 		android_jni_devices_next(devices, &device, &busnum, &devaddr))
 	{
+		/* FIXME: session ID is not guaranteed unique as addresses can wrap and
+		* will be reused. instead we should add a simple sysfs attribute with
+		* a session ID. */
+		unsigned long session_id = busnum << 8 | devaddr;
+
+		if(session_id_count < LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL){
+			session_id_avail[session_id_count] = session_id;
+			session_id_count++;
+		}
 
 		if (linux_enumerate_device(ctx, busnum, devaddr, NULL) < 0)
 			usbi_dbg(ctx, "failed to enumerate android device %d/%d", busnum, devaddr);
@@ -559,6 +576,46 @@ static int android_jni_scan_devices(struct libusb_context *ctx)
 	}
 
 	android_jni_devices_free(devices);
+
+	// for every session id not found, disconnect
+	unsigned long session_id_del[LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL];
+	size_t session_id_del_count = 0;
+
+	{
+		struct libusb_device *dev;
+		struct libusb_device *ret = NULL;
+		usbi_mutex_lock(&ctx->usb_devs_lock);
+		for_each_device(ctx, dev) {
+			uint8_t found = 0;
+			for(size_t i = 0; i < session_id_count; i++){
+				if(dev->session_data == session_id_avail[i]){
+					found = 1;
+					break;
+				}
+			}
+
+			if(!found){
+				// "disconnect"
+				if(session_id_del_count < LIBUSB_ANDROIND_JNI_MAX_NUM_DEVICES_POLL){
+					session_id_del[session_id_del_count] = dev->session_data;
+					session_id_del_count++;
+				}
+			}
+		}
+		usbi_mutex_unlock(&ctx->usb_devs_lock);
+	}
+
+	// Actually disconnect
+	for(size_t i = 0; i < session_id_del_count; i++) {
+		struct libusb_device *dev;
+		dev = usbi_get_device_by_session_id(ctx, session_id_del[i]);
+		if (dev) {
+			usbi_disconnect_device(dev);
+			libusb_unref_device(dev);
+		} else {
+			usbi_dbg(ctx, "device not found for session %lx", session_id_del[i]);
+		}
+	}
 
 	return LIBUSB_SUCCESS;
 }
@@ -641,6 +698,17 @@ static int android_jni_initialize_device(struct libusb_device *dev, uint8_t busn
 	return LIBUSB_SUCCESS;
 }
 
+void android_jni_hotplug_poll()
+{
+	struct libusb_context *ctx;
+	// Poll each context
+	usbi_mutex_static_lock(&active_contexts_lock);
+	for_each_context(ctx) {
+		linux_scan_devices(ctx);
+	}
+	usbi_mutex_static_unlock(&active_contexts_lock);
+}
+
 #endif
 
 static int linux_scan_devices(struct libusb_context *ctx)
@@ -651,6 +719,8 @@ static int linux_scan_devices(struct libusb_context *ctx)
 
 #if defined(HAVE_LIBUDEV)
 	ret = linux_udev_scan_devices(ctx);
+#elif defined(__ANDROID__)
+	ret = android_jni_scan_devices(ctx);
 #else
 	ret = linux_default_scan_devices(ctx);
 #endif
@@ -2998,6 +3068,12 @@ const struct usbi_os_backend usbi_backend = {
 	.caps = USBI_CAP_HAS_HID_ACCESS|USBI_CAP_SUPPORTS_DETACH_KERNEL_DRIVER,
 	.init = op_init,
 	.exit = op_exit,
+
+// Another option, disable hotplug all together
+#if __ANDROID__
+	//.get_device_list = android_jni_get_device_list,
+#endif
+
 	.set_option = op_set_option,
 	.hotplug_poll = op_hotplug_poll,
 	.get_active_config_descriptor = op_get_active_config_descriptor,

--- a/libusb/os/linux_usbfs.h
+++ b/libusb/os/linux_usbfs.h
@@ -164,10 +164,12 @@ int linux_udev_start_event_monitor(void);
 int linux_udev_stop_event_monitor(void);
 int linux_udev_scan_devices(struct libusb_context *ctx);
 void linux_udev_hotplug_poll(void);
-#else
+#elif !defined(__ANDROID__)
 int linux_netlink_start_event_monitor(void);
 int linux_netlink_stop_event_monitor(void);
 void linux_netlink_hotplug_poll(void);
+#elif defined(__ANDROID__)
+void android_jni_hotplug_poll();
 #endif
 
 static inline int linux_start_event_monitor(void)
@@ -196,6 +198,8 @@ static inline void linux_hotplug_poll(void)
 	linux_udev_hotplug_poll();
 #elif !defined(__ANDROID__)
 	linux_netlink_hotplug_poll();
+#elif defined(__ANDROID__)
+	android_jni_hotplug_poll();
 #endif
 }
 


### PR DESCRIPTION
Hi @xloem 

As discussed, my modifications on Android JNI, to support device relisting.

I've consider disabling hotplug capabilities alltogether and only rely on manual device relisting, but that dragged a couple of issues along, which I didn't have time to dig into.

This keeps "hotplug" (as before), but on a poll (eg when retrieving a list of devices again), it checks which devices arrived and which got disconnected compared to previous list. Based on this information it then calls the corresponding functions to either reenumerate or disconnect.

Thoughts and comments welcome - I haven't tested heavily in the field yet, but in my PoC seems to work as expected 

EDIT: Also addresses PendingIntent.FLAG_IMMUTABLE for Android 12